### PR TITLE
Small fix on URI requirement and added a paragraph explaining the issue with iso 639

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,7 +262,9 @@
         
         <p class="advisement" id="ltli-valid-content-req"><a href="#ltli-valid-content-req" class="self">&#x200B;</a>Specifications SHOULD require content authors use <a>valid</a> language tags.</p>
         <p class="advisement" id="ltli-validator-req"><a href="#ltli-validator-req" class="self">&#x200B;</a>Content validators SHOULD check if content uses <a>valid</a> language tags where feasible.</p>
-		<p class="advisement" id="ltli-language-information-in-uris-req"><a href="#ltli-language-information-in-uris-req" class="self">&#x200B;</a>Applications (e.g. in the realm of RDF) that provide language information as part of URIs SHOULD use [[BCP47]].</p>
+		<p class="advisement" id="ltli-language-information-in-uris-req"><a href="#ltli-language-information-in-uris-req" class="self">&#x200B;</a>Applications that provide language information as part of URIs (e.g. in the realm of RDF) SHOULD use [[BCP47]].</p>
+		
+		    <p>Currently, URIs expressing language information often use values from parts of ISO 639. This leads to situations in which there are ambiguities about what the proper value should be, e.g. for German "ger" from ISO 639-1 or "de" from ISO 639-2. By using BCP 47 and its language sub tag registry, such ambiguities can be avoided, e.g. for German, the registry contains only “de”.</p>
         
         <p class="advisement" id="ltli-range-type-req"><a href="#ltli-range-type-req" class="self">&#x200B;</a>Specifications that define language tag matching or <a>language negotiation</a> MUST specify whether language ranges used are a <a>basic language range</a> or an <a>extended language range</a>.</p>
         

--- a/index.html
+++ b/index.html
@@ -264,7 +264,7 @@
         <p class="advisement" id="ltli-validator-req"><a href="#ltli-validator-req" class="self">&#x200B;</a>Content validators SHOULD check if content uses <a>valid</a> language tags where feasible.</p>
 		<p class="advisement" id="ltli-language-information-in-uris-req"><a href="#ltli-language-information-in-uris-req" class="self">&#x200B;</a>Applications that provide language information as part of URIs (e.g. in the realm of RDF) SHOULD use [[BCP47]].</p>
 		
-		    <p>Currently, URIs expressing language information often use values from parts of ISO 639. This leads to situations in which there are ambiguities about what the proper value should be, e.g. for German "ger" from ISO 639-1 or "de" from ISO 639-2. By using BCP 47 and its language sub tag registry, such ambiguities can be avoided, e.g. for German, the registry contains only “de”.</p>
+		    <p>Currently, URIs expressing language information often use values from parts of ISO 639. This leads to situations in which there are ambiguities about what the proper value should be, e.g. for German <code>de</code> from ISO 639-1 or <code>ger</code> from ISO 639-2. By using BCP 47 and its language sub tag registry, such ambiguities can be avoided, e.g. for German, the registry contains only <code>de</code>.</p>
         
         <p class="advisement" id="ltli-range-type-req"><a href="#ltli-range-type-req" class="self">&#x200B;</a>Specifications that define language tag matching or <a>language negotiation</a> MUST specify whether language ranges used are a <a>basic language range</a> or an <a>extended language range</a>.</p>
         


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fsasaki/ltli/pull/11.html" title="Last updated on Jul 9, 2020, 4:11 PM UTC (a12c9d5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ltli/11/e3ff7ef...fsasaki:a12c9d5.html" title="Last updated on Jul 9, 2020, 4:11 PM UTC (a12c9d5)">Diff</a>