### PR TITLE
Additional edits for clarity and consistency

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
     <section id="introduction">
       <h2>Introduction</h2>
 
-        <p>Language tags and locales are one of the fundamental building blocks of <a>internationalization</a> of the Web. In this document you will find definitions for much of the basic terminology related to this aspect of <a>I18N</a>.</p>      
+        <p>Language tags and locales are some of the fundamental building blocks of <a>internationalization</a> (<q><a>i18n</a></q>) of the Web. In this document you will find definitions for much of the basic terminology related to this aspect of <a>internationalization</a>.</p>      
         
         <p>This document also provides terminology and best practices needed by specification authors for the identification of <a>natural language</a> values in document formats or protocols and which are recommended by the Internationalization (I18N) Working Group. These (and many other) best practices, along with links to supporting materials, can also be found in the <cite>Internationalization Best Practices for Spec Developers</cite> [[INTERNATIONAL-SPECS]]. In addition to the best practices found here, additional best practices relating to language metadata on the Web can be found in [[STRING-META]].</p>
         
@@ -108,17 +108,15 @@
         
         <p class="advisement" id="ltli-obs-language-tag-ref"><a href="#ltli-obs-language-tag-ref" class="self">&#x200B;</a>Specifications that need to preserve compatibility with obsolete versions of [[BCP47]] MUST reference the production <code>obs-language-tag</code> in [[BCP47]].</p>
         
-        <p>Beginning with [[RFC4646]], [[BCP47]] defined a more complex, machine-readable syntax for language tags. Some specifications might desire or require compatibility with the older language tag grammar found in previous versions of BCP47 (specifically [[RFC1766]] and [[RFC3066]]). This grammar was more permissive and is described in [[BCP47]] as the ABNF production <code>obs-language-tag</code>. [[RFC4646]], which introduced the current grammar for language tags, is itself obsolete.</p>
+        <p>Beginning with [[RFC4646]], [[BCP47]] defined a more complex, machine-readable syntax for language tags. Some specifications might desire or require compatibility with the older language tag grammar found in previous versions of BCP47 (specifically [[RFC1766]] and [[RFC3066]]). This grammar was more permissive and is described in [[BCP47]] as the ABNF production <code>obs-language-tag</code>. [[RFC4646]], which introduced the current grammar for language tags, was replaced by [[RFC5646]], which is the current [[BCP47]].</p>
         
         <p class="advisement" id="ltli-language-information-in-uris-req"><a href="#ltli-language-information-in-uris-req" class="self">&#x200B;</a>Applications that provide language information as part of URIs (e.g. in the realm of RDF) SHOULD use [[BCP47]].</p>
 		
 		<p>Currently, URIs expressing language information often use values from parts of ISO 639. This leads to situations in which there are ambiguities about what the proper value should be, e.g. for German <code>de</code> from ISO 639-1 or <code>ger</code> from ISO 639-2. By using BCP 47 and its language sub tag registry, such ambiguities can be avoided, e.g. for German, the registry contains only <code>de</code>.</p>
-
-        <p class="advisement" id="ltli-keep-extensions"><a class="self" href="#ltli-keep-extensions">&#x200B;</a>Specifications SHOULD NOT restrict the length of language tags or permit or encourage the removal of extensions.</p>
         
         <p class="definition"><dfn data-lt="subtag|subtags">Subtag</dfn>. A sequence of ASCII letters or digits separated from other subtags by the hyphen-minus character and identifying a specific element of meaning withing the overall <a>language tag</a>. In [[BCP47]], subtags can consist of upper or lowercase ASCII letters (the case carries no distinction) or ASCII digits. Subtags are limited to no more than eight characters (although additional length restrictions apply depending on the specific use of the subtag).</p>
         
-        <p>Selecting content or behavior based on the language tag requires a few additional concepts defined by [[RFC4647]]. In this document, we adopt the following terminology:</p>
+        <p>Selecting content or behavior based on the language tag requires a few additional concepts defined by [[BCP47]] (in [[RFC4647]]). In this document, we adopt the following terminology, which is taken directly from [[BCP47]]:</p>
           
         <p class="definition"><dfn data-lt="iana language subtag registry|subtag registry|registry|lstr">IANA Language Subtag Registry</dfn>. A machine-readable text file available via IANA which contains a comprehensive list of all of the subtags valid in language tags. (Link: <a href="https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry">Registry</a>)</p>
         
@@ -151,7 +149,8 @@
         
         <p>In particular, [[RFC6067]] defines the <cite>BCP 47 Extension U</cite>, also known as "Unicode Locales". This extension to [[BCP47]] provides additional subtag sequences for selecting specific locale variations.</p>
         
-          
+        <p class="advisement" id="ltli-keep-extensions"><a class="self" href="#ltli-keep-extensions">&#x200B;</a>Specifications SHOULD NOT restrict the length of language tags or permit or encourage the removal of extensions.</p>
+                  
         <p class="definition"><dfn data-lt="language range|range|language-range|language ranges">Language range</dfn>. A string similar in structure to a language tag that is used for "identifying sets of language tags that share specific attributes".</p>
         
         <p class="definition"><dfn>Language priority list</dfn>. A collection of one or more <a>language ranges</a> identifying the user's language preferences for use in matching. As the name suggests, such lists are normally ordered or weighted according to the user's preferences. The HTTP [[RFC2616]] <code>Accept-Language</code> [[RFC3282]] header is an example of one kind of language priority list.</p>

--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@
         
         <p class="advisement" id="ltli-obs-language-tag-ref"><a href="#ltli-obs-language-tag-ref" class="self">&#x200B;</a>Specifications that need to preserve compatibility with obsolete versions of [[BCP47]] MUST reference the production <code>obs-language-tag</code> in [[BCP47]].</p>
         
-        <p>Beginning with [[RFC4646]], [[BCP47]] defined a more complex, machine-readable syntax for language tags. Some specifications might desire or require compatibility with the older language tag grammar found in previous versions of BCP47 (specifically [[RFC1766]] and [[RFC3066]]). This grammar was more permissive and is described in [[BCP47]] as the ABNF production <code>obs-language-tag</code>. [[RFC4646]], which introduced the current grammar for language tags, was replaced by [[RFC5646]], which is the current [[BCP47]].</p>
+        <p>Beginning with [[RFC4646]], [[BCP47]] defined a more complex, machine-readable syntax for language tags. This syntax is stable and is not expected to change in the foreseeable future. Some specifications might desire or require compatibility with the older language tag grammar found in previous versions of BCP47 (specifically [[RFC1766]] and [[RFC3066]]). This grammar was more permissive and is described in [[BCP47]] as the ABNF production <code>obs-language-tag</code>. [[RFC4646]], which introduced the current grammar for language tags, was replaced by [[RFC5646]] as part of the current [[BCP47]].</p>
         
         <p class="advisement" id="ltli-language-information-in-uris-req"><a href="#ltli-language-information-in-uris-req" class="self">&#x200B;</a>Applications that provide language information as part of URIs (e.g. in the realm of RDF) SHOULD use [[BCP47]].</p>
 		
@@ -116,7 +116,7 @@
         
         <p class="definition"><dfn data-lt="subtag|subtags">Subtag</dfn>. A sequence of ASCII letters or digits separated from other subtags by the hyphen-minus character and identifying a specific element of meaning withing the overall <a>language tag</a>. In [[BCP47]], subtags can consist of upper or lowercase ASCII letters (the case carries no distinction) or ASCII digits. Subtags are limited to no more than eight characters (although additional length restrictions apply depending on the specific use of the subtag).</p>
         
-        <p>Selecting content or behavior based on the language tag requires a few additional concepts defined by [[BCP47]] (in [[RFC4647]]). In this document, we adopt the following terminology, which is taken directly from [[BCP47]]:</p>
+        <p>Selecting content or behavior based on the language tag requires a few additional concepts defined by [[BCP47]] (in [[RFC4647]]). In this document, we adopt the following terminology taken directly from [[BCP47]]:</p>
           
         <p class="definition"><dfn data-lt="iana language subtag registry|subtag registry|registry|lstr">IANA Language Subtag Registry</dfn>. A machine-readable text file available via IANA which contains a comprehensive list of all of the subtags valid in language tags. (Link: <a href="https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry">Registry</a>)</p>
         

--- a/index.html
+++ b/index.html
@@ -126,19 +126,19 @@
           
         <p>[[BCP47]] defines two different levels of conformance. See <a href="https://tools.ietf.org/html/bcp47#section-2.2.9">classes of conformance</a> in [[BCP47]] for specifics. For language tags, the levels of conformance correspond to type of checking that an implementation applies to language tag values.</p>
         
-        <p class="definition"><dfn data-lt="well-formed|well-formed language tag">Well-formed language tag</dfn>. A language tag that follows the grammar defined in [[BCP47]]. That is, it is structurally correct, consisting of ASCII letters and digit <a>subtags</a> of the prescribed length, separated by hyphens.</p>
+        <p class="definition"><dfn data-lt="well-formed|well-formed language tag|well-formed language tags">Well-formed language tag</dfn>. A language tag that follows the grammar defined in [[BCP47]]. That is, it is structurally correct, consisting of ASCII letters and digit <a>subtags</a> of the prescribed length, separated by hyphens.</p>
         
-        <p class="definition"><dfn data-lt="valid|valid language tag">Valid language tag</dfn>. A language tag that is <a>well-formed</a> and has also been checked to ensure that each of the subtags appears in the <a>IANA Language Subtag Registry</a>.</p>
+        <p class="definition"><dfn data-lt="valid|valid language tag|valid language tags">Valid language tag</dfn>. A language tag that is <a>well-formed</a> and has also been checked to ensure that each of the subtags appears in the <a>IANA Language Subtag Registry</a>.</p>
         
         <p class="advisement" id="ltli-well-formed-req"><a href="#ltli-well-formed-req" class="self">&#x200B;</a>Specifications SHOULD require that language tags be <a>well-formed</a>.</p>
         
         <p class="advisement" id="ltli-valid-req"><a href="#ltli-valid-req" class="self">&#x200B;</a>Specifications MAY require that language tags be <a>valid</a>.</p>
         
-        <p class="advisement" id="ltli-valid-content-req"><a href="#ltli-valid-content-req" class="self">&#x200B;</a>Specifications SHOULD require that content authors use <a>valid</a> language tags.</p>
+        <p class="advisement" id="ltli-valid-content-req"><a href="#ltli-valid-content-req" class="self">&#x200B;</a>Specifications SHOULD require that content authors use <a>valid language tags</a>.</p>
         
         <p>Note that this is stricter than what is recommended for implementations.</p>
         
-        <p class="advisement" id="ltli-validator-req"><a href="#ltli-validator-req" class="self">&#x200B;</a>Content validators SHOULD check if content uses <a>valid</a> language tags where feasible.</p>
+        <p class="advisement" id="ltli-validator-req"><a href="#ltli-validator-req" class="self">&#x200B;</a>Content validators SHOULD check if content uses <a>valid language tags</a> where feasible.</p>
         
         <p>Checking if a tag is <a>valid</a> requires access to or a copy of the <a>registry</a> plus additional runtime logic. While content authors are advised to choose, generate, and exchange only valid values, language tag matching and other common language tag operations are designed so that validity checking is not needed. Features or functions that need to understand the specific semantic content of subtags are the main reason that a specification would normatively require <a>valid</a> tags as part of the protocol or document format.</p>
         
@@ -237,9 +237,9 @@
         
         <p class="definition"><dfn data-lt="common locale data repository|CLDR">Common Locale Data Repository</dfn> (or <em>[[CLDR]]</em>). The Common Locale Data Repository is a Unicode Consortium project that defines, collects, and curates sets of data needed to enable <a>locales</a> in systems or operating environments. CLDR data and its locale model are widely adopted, particularly in browsers.</p>
         
-        <p class="definition"><dfn data-lt="unicode locale|unicode locale identifier|unicode locale identifiers|unicode locales">Unicode Locale Identifier</dfn> or <em>Unicode Locale</em>. A <a>language tag</a> that follows the additional rules and restrictions on subtag choice defined in UTR#35 [[LDML]]. Any valid Unicode locale identifier is also a <a>valid</a> [[BCP47]] <a>language tag</a>, but a few <a>valid</a> <a>language tags</a> are not also valid Unicode locale identifiers.</p>
+        <p class="definition"><dfn data-lt="unicode locale|unicode locale identifier|unicode locale identifiers|unicode locales">Unicode Locale Identifier</dfn> or <em>Unicode Locale</em>. A <a>language tag</a> that follows the additional rules and restrictions on subtag choice defined in UTR#35 [[LDML]]. Any valid Unicode locale identifier is also a <a>valid</a> [[BCP47]] <a>language tag</a>, but a few <a>valid language tags</a> are not also valid Unicode locale identifiers.</p>
         
-        <p class="definition"><dfn data-lt="canonical Unicode locale identifier|canonical tag|canonical locale">Canonical Unicode locale identifier</dfn>. A <a>well-formed</a> language tag resulting from the application of the <a>Unicode locale identifier</a> canonicalization rules found in [[LDML]] (see <a href="https://www.unicode.org/reports/tr35/#Unicode_locale_identifier">Section 3</a>). This process converts any <a>valid</a> [[BCP47]] <a>language tag</a> into a valid <a>Unicode locale identifier</a>.  For example, deprecated subtags or irregular grandfathered tags are replaced with their preferred value from the <a>IANA language subtag registry</a>.</p>
+        <p class="definition"><dfn data-lt="canonical Unicode locale identifier|canonical tag|canonical locale">Canonical Unicode locale identifier</dfn>. A <a>well-formed language tag</a> resulting from the application of the <a>Unicode locale identifier</a> canonicalization rules found in [[LDML]] (see <a href="https://www.unicode.org/reports/tr35/#Unicode_locale_identifier">Section 3</a>). This process converts any <a>valid</a> [[BCP47]] <a>language tag</a> into a valid <a>Unicode locale identifier</a>.  For example, deprecated subtags or irregular grandfathered tags are replaced with their preferred value from the <a>IANA language subtag registry</a>.</p>
                 
         <p>[[CLDR]] defines and maintains two <a>language tag extensions</a> ([[RFC6067]] and [[RFC6497]]) that are related to <a>Unicode locale identifiers</a>. These extensions allow a <a>language tag</a> to express some <a>international preference</a> variations that go beyond linguistic or regional variation or to select formatting behavior or content when there are multiple options or user preferences within a given locale. <a>Unicode locale identifiers</a> are not required to include these extensions: they are only used when the locale being identified requires additional tailoring provided by one of these extensions. [[CLDR]] also applies specific interpretation of certain subtags when used as a locale identifier. See <a href="https://www.unicode.org/reports/tr35/tr35.html#Unicode_locale_identifier">Section 3.2</a> of [[LDML]] for details.</p>
         


### PR DESCRIPTION
As part of a final read-through before we go wider with review, I made edits for consistency and clarity. These include:

- made links to `valid` and `well-formed` include the word `language tag[s]` as needed
- corrected capitalization of I18N -> i18n (our house style) and removed standalone use in the introduction
- moved one requirement down so that it will make more sense
- clarified RFC4646's relationship to BCP47
- added a sentence to clarify that 4646's grammar is stable and unlikely to change
- clarified that terminology is taken from BCP47 (not invented here)

These changes are all rather editorial, so I'm going to merge them directly.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aphillips/ltli/pull/28.html" title="Last updated on Oct 2, 2020, 3:03 PM UTC (9b90ba3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ltli/28/89b2e51...aphillips:9b90ba3.html" title="Last updated on Oct 2, 2020, 3:03 PM UTC (9b90ba3)">Diff</a>